### PR TITLE
Allow use of base classes in permission checks [SCI-4597]

### DIFF
--- a/lib/canaid/permissions_holder.rb
+++ b/lib/canaid/permissions_holder.rb
@@ -61,9 +61,9 @@ module Canaid
       check_if_exists(name)
 
       # Check if correct object class was specified
-      raise ArgumentError.new(
-        "Object of incorrect class specified when calling permission #{name}!"
-      ) if obj.class.name != @can_obj_classes[name]
+      unless obj.is_a?(@can_obj_classes[name].constantize)
+        raise ArgumentError, "Object of incorrect class specified when calling permission #{name}!"
+      end
 
       result = true
       @cans[name].each do |perm|


### PR DESCRIPTION
It makes possible use of base classes in permission checks, useful for creation of common permission checks, for example for models using STI  